### PR TITLE
[PD1-111]: Adicionar o parâmetro do id do usuário ao fazer as requisições para leituras

### DIFF
--- a/src/controllers/reading.controller.js
+++ b/src/controllers/reading.controller.js
@@ -3,7 +3,7 @@ const { validationResult } = require("express-validator");
 
 exports.getAllReadings = async (req, resp, next) => {
     try {
-        const readings = await readingBusiness.getAllReadings(1);
+        const readings = await readingBusiness.getAllReadings(req.userId);
         resp.json(readings);
     } catch(e) {
         next(e);
@@ -12,7 +12,7 @@ exports.getAllReadings = async (req, resp, next) => {
 
 exports.getReadingReadings = async (req, resp, next) => {
     try {
-        const readings = await readingBusiness.getReadingReadings(1);
+        const readings = await readingBusiness.getReadingReadings(req.userId);
         resp.json(readings);
     } catch(e) {
         next(e);
@@ -21,7 +21,7 @@ exports.getReadingReadings = async (req, resp, next) => {
 
 exports.getReadReadings = async (req, resp, next) => {
     try {
-        const readings = await readingBusiness.getReadReadings(1);
+        const readings = await readingBusiness.getReadReadings(req.userId);
         resp.json(readings);
     } catch(e) {
         next(e);
@@ -30,7 +30,7 @@ exports.getReadReadings = async (req, resp, next) => {
 
 exports.getWantedReadings = async (req, resp, next) => {
     try {
-        const readings = await readingBusiness.getWantedReadings(1);
+        const readings = await readingBusiness.getWantedReadings(req.userId);
         resp.json(readings);
     } catch(e) {
         next(e);
@@ -41,7 +41,7 @@ exports.startReading = async (req, resp, next) => {
     try {
         validationResult(req).throw()
         const {bookId, googleId, status} = req.body;
-        await readingBusiness.startReading(1, bookId, googleId, status);
+        await readingBusiness.startReading(req.userId, bookId, googleId, status);
         resp.sendStatus(201);
     } catch(e) {
         next(e);
@@ -52,8 +52,7 @@ exports.deleteReading = async (req, resp, next) => {
     try {
         validationResult(req).throw()
         const { bookId } = req.params;
-        console.log(bookId)
-        await readingBusiness.deleteReading(1, bookId);
+        await readingBusiness.deleteReading(req.userId, bookId);
         resp.sendStatus(204);
     } catch(e) {
         next(e);
@@ -65,7 +64,7 @@ exports.updateBookStatus = async (req, resp, next) => {
         validationResult(req).throw()
         const { bookId } = req.params;
         const { currentStatus, initialPage, currentPage, readingTime } = req.body;
-        await readingBusiness.updateBookStatus(1, bookId, currentStatus, initialPage, currentPage, readingTime);
+        await readingBusiness.updateBookStatus(req.userId, bookId, currentStatus, initialPage, currentPage, readingTime);
         resp.sendStatus(204);
     } catch(e) {
         next(e);

--- a/src/controllers/utils/validate-token.js
+++ b/src/controllers/utils/validate-token.js
@@ -6,9 +6,12 @@ exports.tokenValidation = (req, resp, next) => {
     try {
         if (!token) return resp.status(401).json({ msg: "You don't have permission to do this request" });
 
-        verify(token, process.env.SECRET, (e) => {
-            console.log(e)
-            if (e) return resp.status(401).json({ msg: "Your session has expired" });
+        verify(token, process.env.SECRET, (e, payload) => {
+            if (e) {
+                console.log(e);
+                return resp.status(401).json({ msg: "Your session has expired" });
+            }
+            req.userId = payload.uso_id;
             next();
         });
     } catch(e) {

--- a/src/controllers/utils/validate-token.js
+++ b/src/controllers/utils/validate-token.js
@@ -7,10 +7,7 @@ exports.tokenValidation = (req, resp, next) => {
         if (!token) return resp.status(401).json({ msg: "You don't have permission to do this request" });
 
         verify(token, process.env.SECRET, (e, payload) => {
-            if (e) {
-                console.log(e);
-                return resp.status(401).json({ msg: "Your session has expired" });
-            }
+            if (e) return resp.status(401).json({ msg: "Your session has expired" });
             req.userId = payload.uso_id;
             next();
         });


### PR DESCRIPTION
- Ao validar o JWT, em caso de sucesso, é armazenado o id do usuário no objeto da requisição
- Esse id armazenado é usado para recuperar as informações de leituras do usuário a quem o token se refere